### PR TITLE
signal use-next-route condition with signal instead of error

### DIFF
--- a/route.lisp
+++ b/route.lisp
@@ -47,7 +47,7 @@
 (defun next-route ()
   "Lets the routing system know to re-route the current request, excluding this
    route from the available options."
-  (error 'use-next-route))
+  (signal 'use-next-route))
 
 (defun find-route (method resource &key exclude host)
   "Given a method and a resource, find the best matching route."


### PR DESCRIPTION
makes more sense as next-route is not an error. Only difference is that an unhandled condition that is signaled with signal instead of error just returns nil instead of bubbling up.