### PR TITLE
Don't break on EPIPE & ECANCELED; always allow declarations in route definitions.

### DIFF
--- a/route.lisp
+++ b/route.lisp
@@ -189,8 +189,8 @@
                                    (lambda (,bind-request ,bind-response &rest ,bind-args)
                                      ,(or docstring "")
                                      (declare (ignorable ,bind-request))
-                                     ,(when ignore-bind-args
-                                        `(declare (ignore ,bind-args)))
+                                     ,@(when ignore-bind-args
+                                         `((declare (ignore ,bind-args))))
                                      ,@body)
                                    :regex ,regex
                                    :case-sensitive ,case-sensitive


### PR DESCRIPTION
On Linux, EPIPE & ECANCELED that weren't handled properly were showing up when reloading a page multiple times without waiting for previous requests to finish.
Also, in case BIND-ARGS was specified, NIL was inserted after first DECLARE in route body, breaking declarations (sbcl).
This needs orthecreedence/cl-async#121