### PR TITLE
Don't ignore explicitly-passed NIL response bodies.

### DIFF
--- a/request-response.lisp
+++ b/request-response.lisp
@@ -117,7 +117,7 @@
                   str)))
     str))
 
-(defun send-response (response &key (status 200) headers body (close nil close-specified-p))
+(defun send-response (response &key (status 200) headers (body nil body-specified-p) (close nil close-specified-p))
   "Send a response to an incoming request. Takes :status, :headers, and :body
    keyword arguments, which together form an entire response.
 
@@ -141,7 +141,7 @@
              :code -1
              :msg "Trying to operate on a closed socket"
              :socket socket))
-  
+
     ;; run the response hooks
     (do-run-hooks (socket) (run-hooks :response-started response request status headers body)
       (let* ((response-headers (response-headers response))
@@ -160,7 +160,7 @@
                              (t
                               (error "Unsupported body type (need string or octet vector): ~a~%" (type-of body)))))
              (status-text (lookup-status-text status)))
-        (when (and body (not (get-header headers :content-length)))
+        (when (and body-specified-p (not (get-header headers :content-length)))
           (set-header headers :content-length (length body-enc)))
         ;; make writing a single HTTP line a bit less painful
         (flet ((write-http-line (format-str &rest format-args)


### PR DESCRIPTION
This change makes SEND-RESPONSE do what the docs say: set
`content-length` as long as `:body` was supplied and the header isn't
already set.

It's a common impulse to pass NIL for responses that have no body (e.g.
404 response, or a session heartbeat url), but wookie currently ignores
them and doesn't set content-length. Without content-length and in the
absence of other headers, the browser will wait for a connection close to
end the response. If the server doesn't close the connection, the browser
hangs.

Instead, if the body has been explicitly supplied, always set a
content-length. This allows NIL to be used for empty bodies, without
breaking START-RESPONSE's use of SEND-RESPONSE to set headers.