### PR TITLE
Inherit from `cl:error` in `wookie-error`.

### DIFF
--- a/error.lisp
+++ b/error.lisp
@@ -1,6 +1,6 @@
 (in-package :wookie)
 
-(define-condition wookie-error ()
+(define-condition wookie-error (error)
   ((msg :initarg :msg :reader wookie-error-msg :initform nil)
    (socket :initarg :socket :reader wookie-error-socket :initform nil))
   (:report (lambda (c s) (format s "Wookie error: ~a" (wookie-error-msg c))))


### PR DESCRIPTION
Any condition that represents a situation that must be handled callers
should inherit from at least `serious-condition`; in this case, since the
condition represents an actual error, `error` is appropriate. Without this,
code that handles `error` or `serious-condition` will miss any condition that
inherits from this -- for example, signalling `wookie-error` from a clack
handler bypasses clack's error-catching mechanism and invokes the debugger
in the server.