### PR TITLE
Quicklisp symbols

### DIFF
--- a/plugin.lisp
+++ b/plugin.lisp
@@ -33,7 +33,7 @@
 (defun unload-plugin (plugin-name)
   "Unload a plugin from the wookie system. If it's currently registered, its
    unload-function will be called.
-   
+
    Also unloads any current plugins that depend on this plugin. Does this
    recursively so all depencies are always resolved."
   (vom:debug1 "(plugin) Unload plugin ~s" plugin-name)
@@ -157,7 +157,7 @@
 
 (defparameter *current-plugin-name* nil
   "Used by load-plugins to tie ASDF systems to a :plugin-name")
-  
+
 (defparameter *scanner-plugin-name*
   (cl-ppcre:create-scanner "[/\\\\]([a-z-_]+)[/\\\\]?$" :case-insensitive-mode t)
   "Basically unix's basename in a regex.")
@@ -207,5 +207,3 @@
      (defun ,name ,args ,@body)
      (shadowing-import ',name :wookie-plugin-export)
      (export ',name :wookie-plugin-export)))
-
-

--- a/plugin.lisp
+++ b/plugin.lisp
@@ -108,6 +108,11 @@
                        (error "Symbol ~A is missing from package ~A(!)" '#:quickload pkg))
                    (asdf:oos 'asdf:load-op system))))
            (load-system-with-handler (system &key use-quicklisp)
+             ;; We only want to handle errors with a particular
+             ;; dynamic type, so we need to establish a handler for a
+             ;; super-type of those errors, check the type
+             ;; dynamically, and let the condition fall through if it
+             ;; doesn't match.
              (handler-bind
                  ((error (lambda (c)
                            (let* ((ql-pkg (find-package :ql))


### PR DESCRIPTION
This PR is a preliminary change to fix issues using quicklisp symbols in the plugin code. I'm afraid I haven't tested it, since I'm really not familiar with wookie's plugin system; if you have suggestions or would like to see a different approach, please let me know.

The problem is that your solution of using macros to avoid errors when quicklisp isn't present is only half-correct. The problem is this: you load the system with quicklisp available, so the macros emit `ql:quickload` & co; asdf caches the resulting fasl file; the system now errors whenever it is loaded from an image without quicklisp (e.g. buildapp with a manifest file) because asdf is loading the cached fasl with quicklisp symbols in it, but the quicklisp package doesn't exist.

This branch does a few things:
1. Converts the macros to local functions
2. Defers symbol lookup to runtime (using `find-symbol`, and not `intern`, because it doesn't have unpleasant side-effects)
3. Tries to warn or error if the quicklisp package was available, but the expected symbols were missing.

There are some other changes that could be made as well:
1. The system name could be reported from asdf errors with `asdf/missing-component:missing-requires`
2. The compiler says the `*log-output*` variable is not actually a special variable (I'm guessing this was meant to be `vom:*log-stream*`?)

Personally, I think wookie should get out of the business of loading code itself. It's a lot of extra complication (there are at least 5 systems for loading lisp code that I know of), and it doesn't seem like it's asking a lot of users to add a system to their dependencies lists and (maybe) insert a one-line `(wookie:register-plugin 'boogle)` line. Still, it's your project; I mostly just want to fix the embedded-symbol issue.