### PR TITLE
Plugin system update

### DIFF
--- a/core-plugins/cookie/plugin.asd
+++ b/core-plugins/cookie/plugin.asd
@@ -1,9 +1,0 @@
-(wookie:defplugin wookie-plugin-core-cookie
-  :author "Andrew Danger Lyon <orthecreedence@gmail.com>"
-  :license "MIT"
-  :version "0.2.1"
-  :description "A cookie plugin for Wookie"
-  :depends-on (#:wookie)
-  :components
-  ((:file "cookie")))
-

--- a/core-plugins/directory-router/plugin.asd
+++ b/core-plugins/directory-router/plugin.asd
@@ -1,8 +1,0 @@
-(wookie:defplugin wookie-plugin-core-directory-router
-  :author "Andrew Danger Lyon <orthecreedence@gmail.com>"
-  :license "MIT"
-  :version "0.2.1"
-  :description "A directory router plugin for Wookie"
-  :depends-on (#:wookie)
-  :components
-  ((:file "directory-router")))

--- a/core-plugins/get/plugin.asd
+++ b/core-plugins/get/plugin.asd
@@ -1,8 +1,0 @@
-(wookie:defplugin wookie-plugin-core-get
-  :author "Andrew Danger Lyon <orthecreedence@gmail.com>"
-  :license "MIT"
-  :version "0.2.1"
-  :description "A GET plugin for Wookie"
-  :depends-on (#:wookie)
-  :components
-  ((:file "get")))

--- a/core-plugins/http-var/plugin.asd
+++ b/core-plugins/http-var/plugin.asd
@@ -1,8 +1,0 @@
-(wookie:defplugin wookie-plugin-core-http-var
-  :author "Andrew Danger Lyon <orthecreedence@gmail.com>"
-  :license "MIT"
-  :version "0.2.1"
-  :description "A plugin that makes accessing GET/POST/multipart form vars easy."
-  :depends-on (#:wookie)
-  :components
-  ((:file "http-var")))

--- a/core-plugins/multipart/plugin.asd
+++ b/core-plugins/multipart/plugin.asd
@@ -1,9 +1,0 @@
-(wookie:defplugin wookie-plugin-core-multipart
-  :author "Andrew Danger Lyon <orthecreedence@gmail.com>"
-  :license "MIT"
-  :version "0.2.1"
-  :description "A multipart plugin for Wookie"
-  :depends-on (#:wookie)
-  :components
-  ((:file "multipart")))
-

--- a/core-plugins/post/plugin.asd
+++ b/core-plugins/post/plugin.asd
@@ -1,8 +1,0 @@
-(wookie:defplugin wookie-plugin-core-post
-  :author "Andrew Danger Lyon <orthecreedence@gmail.com>"
-  :license "MIT"
-  :version "0.2.2"
-  :description "A POST plugin for Wookie"
-  :depends-on (#:wookie #:fast-io #:yason)
-  :components
-  ((:file "post")))

--- a/core-plugins/session/plugin.asd
+++ b/core-plugins/session/plugin.asd
@@ -1,9 +1,0 @@
-(wookie:defplugin wookie-plugin-core-session
-  :author "Andrew Danger Lyon <orthecreedence@gmail.com>"
-  :license "MIT"
-  :version "0.2.1"
-  :description "A session plugin for Wookie"
-  :depends-on (#:wookie #:wookie-plugin-core-cookie)
-  :components
-  ((:file "session")))
-

--- a/plugin.lisp
+++ b/plugin.lisp
@@ -21,6 +21,11 @@
    initialization function called that loads the plugin (called only once, on
    register)."
   (vom:debug1 "(plugin) Register plugin ~s" plugin-name)
+
+  ;; Add to plugin to *available-plugins*.
+  (match-plugin-asdf (read-from-string (format nil ":~a" (file-namestring (package-name *package*))))
+		     (read-from-string (format nil ":~a" (package-name *package*))))
+
   (let ((plugin-entry (list :name plugin-name
                             :init-function init-function
                             :unload-function unload-function)))

--- a/wookie-plugin/cookie.lisp
+++ b/wookie-plugin/cookie.lisp
@@ -1,6 +1,8 @@
-(defpackage :wookie-plugin-core-cookie
-  (:use :cl :wookie-util :wookie))
-(in-package :wookie-plugin-core-cookie)
+(uiop:define-package #:wookie/wookie-plugin/cookie
+  (:documentation "A cookie plugin for Wookie")
+  (:import-from #:wookie)
+  (:use #:cl #:wookie-util #:wookie))
+(in-package #:wookie/wookie-plugin/cookie)
 
 (defparameter *scanner-cookie-split*
   (cl-ppcre:create-scanner ";[ \\s\\t]+")
@@ -63,4 +65,3 @@
   (remove-hook :parsed-headers :cookie-core-parse-vars))
 
 (register-plugin :cookie 'init-cookie-vars 'unload-cookie-vars)
-

--- a/wookie-plugin/directory-router.lisp
+++ b/wookie-plugin/directory-router.lisp
@@ -1,6 +1,8 @@
-(defpackage :wookie-plugin-core-directory-router
-  (:use :cl :wookie-util :wookie))
-(in-package :wookie-plugin-core-directory-router)
+(uiop:define-package #:wookie/wookie-plugin/directory-router
+  (:documentation "A directory router plugin for Wookie")
+  (:import-from #:wookie)
+  (:use #:cl #:wookie-util #:wookie))
+(in-package #:wookie/wookie-plugin/directory-router)
 
 (defparameter *scanner-get-extension*
   (cl-ppcre:create-scanner "^.*\\.([a-z0-9]+)$" :case-insensitive-mode t)

--- a/wookie-plugin/get.lisp
+++ b/wookie-plugin/get.lisp
@@ -1,6 +1,8 @@
-(defpackage :wookie-plugin-core-get
-  (:use :cl :wookie-util :wookie))
-(in-package :wookie-plugin-core-get)
+(uiop:define-package #:wookie/wookie-plugin/get
+  (:documentation "A GET plugin for Wookie")
+  (:import-from #:wookie)
+  (:use #:cl #:wookie-util #:wookie))
+(in-package #:wookie/wookie-plugin/get)
 
 (defun parse-get-vars (request)
   "Grab GET data from parsed URI querystring and set into a hash table stored

--- a/wookie-plugin/http-var.lisp
+++ b/wookie-plugin/http-var.lisp
@@ -1,6 +1,8 @@
-(defpackage :wookie-plugin-core-http-var
-  (:use :cl :wookie-util :wookie :wookie-plugin-export))
-(in-package :wookie-plugin-core-http-var)
+(uiop:define-package #:wookie/wookie-plugin/http-var
+  (:documentation "A plugin that makes accessing GET/POST/multipart form vars easy.")
+  (:import-from #:wookie)
+  (:use #:cl #:wookie-util #:wookie #:wookie-plugin-export))
+(in-package #:wookie/wookie-plugin/http-var)
 
 (defplugfun http-var (request key &key (order '(:get :post :multipart)))
   "Get a data variable from an HTTP request. Checks GET/POST/Multipart, assuming

--- a/wookie-plugin/multipart.lisp
+++ b/wookie-plugin/multipart.lisp
@@ -1,6 +1,8 @@
-(defpackage :wookie-plugin-core-multipart
-  (:use :cl :wookie-util :wookie :wookie-config))
-(in-package :wookie-plugin-core-multipart)
+(uiop:define-package #:wookie/wookie-plugin/multipart
+  (:documentation "A multipart plugin for Wookie")
+  (:import-from #:wookie)
+  (:use #:cl #:wookie-util #:wookie #:wookie-config))
+(in-package #:wookie/wookie-plugin/multipart)
 
 (defvar *tmp-file-counter* 0
   "Holds a value that is incremented for each temporary file generated.")

--- a/wookie-plugin/post.lisp
+++ b/wookie-plugin/post.lisp
@@ -1,6 +1,10 @@
-(defpackage :wookie-plugin-core-post
-  (:use :cl :wookie-util :wookie))
-(in-package :wookie-plugin-core-post)
+(uiop:define-package #:wookie/wookie-plugin/post
+  (:documentation "A POST plugin for Wookie")
+  (:import-from #:wookie)
+  (:import-from #:fast-io)
+  (:import-from #:yason)
+  (:use #:cl #:wookie-util #:wookie))
+(in-package #:wookie/wookie-plugin/post)
 
 (defun check-if-post (request)
   "Check if this request contains POST data, and mark the plugin data as such so

--- a/wookie-plugin/session.lisp
+++ b/wookie-plugin/session.lisp
@@ -1,6 +1,9 @@
-(defpackage :wookie-plugin-core-session
-  (:use :cl :wookie-util :wookie))
-(in-package :wookie-plugin-core-session)
+(uiop:define-package #:wookie/wookie-plugin/session
+  (:documentation "A session plugin for Wookie")
+  (:import-from #:wookie)
+  (:import-from #:wookie/wookie-plugin/cookie)
+  (:use #:cl #:wookie-util #:wookie))
+(in-package #:wookie/wookie-plugin/session)
 
 (defun load-session-data (request response)
   (declare (ignore response))

--- a/wookie.asd
+++ b/wookie.asd
@@ -1,4 +1,5 @@
 (asdf:defsystem wookie
+  :class :package-inferred-system
   :author "Andrew Danger Lyon <orthecreedence@gmail.com>"
   :license "MIT"
   :version "0.3.15"
@@ -31,3 +32,4 @@
    #-(or :wookie-no-ssl) (:file "listener-ssl" :depends-on ("listener"))
    (:file "helper" :depends-on ("listener" "plugin" "package"))))
 
+(asdf:register-system-packages "wookie" '(#:wookie-config #:wookie-util #:wookie-plugin-export))


### PR DESCRIPTION
ASDF really doesn't like the current approach, to the point of the `session` plugin being unloadable nowadays. This also makes `wookie-doc` unloadable.

Changes so far:

1. Converted wookie and its plugins to ASDF `package-inferred-system`s
2. Simplified the plugin loading system, with more to come; the thought being that systems that depend on `wookie` should also explicitly depend on the plugins they need, wherever they may be located. This also renders `load-plugins` redundant.

Would love some feedback from more experienced Lispers, before I go further down this path.